### PR TITLE
Version 2.15.1

### DIFF
--- a/SOURCES/kaosv
+++ b/SOURCES/kaosv
@@ -13,7 +13,7 @@ fi
 ###############################################################################
 
 # Current version of KAOSv
-KV_VERSION="2.15.0"
+KV_VERSION="2.15.1"
 
 ###############################################################################
 
@@ -228,7 +228,7 @@ kv[lock_file]=""
 kv[pid_file]=""
 
 # Service user (String)
-kv[user]="root"
+kv[user]=""
 
 # Service dir (String)
 kv[dir]=""
@@ -564,11 +564,7 @@ kv.readSysconfig() {
 kv.run() {
   [[ $# -eq 0 ]] && kv.log "You can't execute kv.run without arguments" && return 1
 
-  local cmd_user="${kv[user]}"
-
-  [[ -z "$cmd_user" ]] && cmd_user="root"
-
-  kv.runAs "$cmd_user" "$@"
+  kv.runAs "${kv[user]:-root}" "$@"
 
   return $?
 }
@@ -854,7 +850,7 @@ kv.findPID() {
 
     user=$(ps --no-header -p "$pid" -o user)
 
-    if [[ "$user" != "${kv[user]}" ]] ; then
+    if [[ "$user" != "${kv[user]:-root}" ]] ; then
       continue
     fi
 

--- a/kaosv.spec
+++ b/kaosv.spec
@@ -34,7 +34,7 @@
 
 Summary:         Bash lib for SysV init scripts
 Name:            kaosv
-Version:         2.15.0
+Version:         2.15.1
 Release:         0%{?dist}
 Group:           Applications/System
 License:         EKOL
@@ -83,6 +83,9 @@ rm -rf %{buildroot}
 ###############################################################################
 
 %changelog
+* Wed Feb 28 2018 Anton Novojilov <andy@essentialkaos.com> - 2.15.1-0
+- Fixed bug with changing pid directory owner to root if kv[user] not defined
+
 * Fri Feb 23 2018 Anton Novojilov <andy@essentialkaos.com> - 2.15.0-0
 - Brand new PID searching system which works without search pattern
 - Print error if user try to source init script (e.g . script)


### PR DESCRIPTION
#### Bugfixes
* Fixed bug with changing PID directory owner to root if `kv[user]` not defined